### PR TITLE
Allow custom headers to be sent to SuiteCRM for write-requests

### DIFF
--- a/libsuitecrm/crm.py
+++ b/libsuitecrm/crm.py
@@ -2,7 +2,7 @@
 
 import logging
 import urllib
-from typing import Any, Dict, List, Tuple
+from typing import Any, List
 
 import oauthlib.oauth2
 import requests
@@ -374,7 +374,7 @@ class SuiteCRM:
             else:
                 response = None
 
-    def create_record(self, module_name: str, record_data: dict) -> dict[str, Any]:
+    def create_record(self, module_name: str, record_data: dict, headers: dict | None = None) -> dict[str, Any]:
         """Create a record in a given module in the CRM
 
         Calls the endpoint documented at:
@@ -386,6 +386,8 @@ class SuiteCRM:
             Module name to create the record in.
         record_data : dict
             Record data to store.
+        headers : dict, optional
+            Additional headers to include in the request.
 
         Returns
         -------
@@ -397,7 +399,7 @@ class SuiteCRM:
         payload = {"data": {"type": module_name, "attributes": record_data}}
         if "id" in record_data:
             payload["data"]["id"] = record_data["id"]
-        response = self._post("/Api/V8/module", json=payload)
+        response = self._post("/Api/V8/module", json=payload, headers=headers)
 
         if "data" not in response:
             logger.error("Attempt to create record failed: response was missing <data> key")
@@ -415,7 +417,9 @@ class SuiteCRM:
 
         return response["data"]
 
-    def update_record(self, module_name: str, id: str, record_data: dict) -> dict[str, Any]:
+    def update_record(
+        self, module_name: str, id: str, record_data: dict, headers: dict | None = None
+    ) -> dict[str, Any]:
         """Update a record in a given module in the CRM
 
         Calls the endpoint documented at:
@@ -429,6 +433,8 @@ class SuiteCRM:
             ID of the record
         record_data : dict
             Record data to update
+        headers : dict, optional
+            Additional headers to include in the request.
 
         Returns
         -------
@@ -438,7 +444,9 @@ class SuiteCRM:
         entity_name = module_name[:-1] if module_name.endswith("s") else module_name
 
         response = self._patch(
-            "/Api/V8/module", json={"data": {"type": module_name, "id": id, "attributes": record_data}}
+            "/Api/V8/module",
+            json={"data": {"type": module_name, "id": id, "attributes": record_data}},
+            headers=headers,
         )
 
         if "data" not in response:
@@ -457,7 +465,7 @@ class SuiteCRM:
 
         return response["data"]
 
-    def delete_record(self, module_name: str, id: str):
+    def delete_record(self, module_name: str, id: str, headers: dict | None = None):
         """Delete a record from a given module in the CRM
 
         Calls the endpoint documented at:
@@ -469,9 +477,11 @@ class SuiteCRM:
             Module name to delete the record from.
         id : str
             ID of the record
+        headers : dict, optional
+            Additional headers to include in the request.
         """
 
-        response = self._delete(f"/Api/V8/module/{module_name}/{id}")
+        response = self._delete(f"/Api/V8/module/{module_name}/{id}", headers=headers)
 
         if "meta" not in response:
             logger.error("Attempt to delete record failed: response was missing <meta> key")
@@ -487,7 +497,13 @@ class SuiteCRM:
             raise DeleteRecordFailed("Cannot understand response from server")
 
     def create_relationship(
-        self, module_name: str, record_id: str, link_field_name: str, related_module_name: str, related_id: str
+        self,
+        module_name: str,
+        record_id: str,
+        link_field_name: str,
+        related_module_name: str,
+        related_id: str,
+        headers: dict | None = None,
     ):
         """Create a relationship between records across modules in the CRM
 
@@ -506,10 +522,13 @@ class SuiteCRM:
             Module name to create the relationship to.
         related_id : str
             ID of the record to create the relationship to.
+        headers : dict, optional
+            Additional headers to include in the request.
         """
         response = self._post(
             f"/Api/V8/module/{module_name}/{record_id}/relationships/{link_field_name}",
             json={"data": {"type": related_module_name, "id": related_id}},
+            headers=headers,
         )
 
         if "meta" not in response:
@@ -546,7 +565,9 @@ class SuiteCRM:
         response = self._get(f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}")
         return response
 
-    def delete_relationship(self, module_name: str, id: str, link_field_name: str, related_id: str):
+    def delete_relationship(
+        self, module_name: str, id: str, link_field_name: str, related_id: str, headers: dict | None = None
+    ):
         """Delete relationship between records in different modules
 
         Calls the endpoint documented at:
@@ -562,10 +583,21 @@ class SuiteCRM:
             Link field name to delete the relationship.
         related_id : str
             ID of the related record to delete the relationship from.
+        headers : dict, optional
+            Additional headers to include in the request.
         """
-        self._delete(f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}/{related_id}")
+        self._delete(
+            f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}/{related_id}", headers=headers
+        )
 
-    def _request(self, method: str, url: str, params: List[Tuple[str, str]] = None, json: Dict = None):  # noqa: C901
+    def _request(
+        self,
+        method: str,
+        url: str,
+        params: list[tuple[str, str]] = None,
+        json: Any | None = None,
+        headers: dict | None = None,
+    ):  # noqa: C901
         """Internal method to send requests to SuiteCRM which also handles errors
 
         Parameters
@@ -574,10 +606,12 @@ class SuiteCRM:
             Method to call, "GET", "POST", "PATCH", "DELETE"
         url : str
             URL to call.
-        params : List[Tuple[str,str]], optional
+        params : list[tuple[str,str]], optional
             Parameters to include in the request, default None.
-        params : List[Tuple[str,str]], optional
-            Parameters to include in the request, default None.
+        json : Any, optional
+            A JSON serializable Python object to send in the body, default None.
+        headers : dict, optional
+            Additional headers to include in the request.
 
         Returns
         -------
@@ -589,61 +623,63 @@ class SuiteCRM:
         RequestFailed
             If the request failed for some reason.
         """
+        response = None
+
         try:
-            response = self._oauth_session.request(method, url, verify=self._secure, params=params, json=json)
+            response = self._oauth_session.request(
+                method, url, verify=self._secure, params=params, json=json, headers=headers
+            )
             response.raise_for_status()
+
+            resp_json = response.json()
 
         except requests.HTTPError:
 
+            error_message = f"Failed {method} from endpoint {urllib.parse.unquote(response.url)} due to an HTTP error"
+
             try:
                 resp_json = response.json()
+                error_detail = f"Details: {resp_json.get('errors', {}).get('detail', '')}"
             except requests.JSONDecodeError as err:
-                raise RequestFailed(
-                    response.status_code,
-                    response.reason,
-                    f"Failed {method} from endpoint {urllib.parse.unquote(response.url)} but "
-                    f"cannot decode JSON response ({response.text})",
-                    str(err),
-                )
+                error_message += f". Additionally, unable to decode JSON response: {response.text}"
+                error_detail = str(err)
 
-            error_detail = ""
-            if "errors" in resp_json:
-                error_detail = resp_json["errors"].get("detail", "")
-            logger.error(
-                f"Failed {method} from endpoint {urllib.parse.unquote(response.url)} with "
-                f"HTTP {response.status_code} ({error_detail})"
-            )
-            raise RequestFailed(
-                response.status_code,
-                response.reason,
-                f"Failed {method} from endpoint {urllib.parse.unquote(response.url)}",
-                error_detail,
-            )
+            logger.error(f"{error_message} {response.status_code}. {error_detail}")
+
+            raise RequestFailed(response.status_code, response.reason, error_message, error_detail)
 
         except requests.ConnectionError as err:
+            resp_status_code = None
+            resp_status_reason = None
+            if response is not None:
+                resp_status_code = response.status_code
+                resp_status_reason = response.reason
+
+            error_message = f"Failed {method} from endpoint {urllib.parse.unquote(url)} due to a connection error"
+
+            logger.error(f"{error_message}. {str(err)}")
+
             raise RequestFailed(
-                response.status_code,
-                response.reason,
-                f"Failed {method} from endpoint {urllib.parse.unquote(response.url)} as there was a connection error",
+                resp_status_code,
+                resp_status_reason,
+                error_message,
                 str(err),
             )
 
-        try:
-            resp_json = response.json()
         except requests.JSONDecodeError as err:
-            fh = open("dump.txt", "w")
-            fh.write(response.text)
-            fh.close()
-            raise RequestFailed(
-                response.status_code,
-                response.reason,
-                f"Cannot decode response JSON from {method} to endpoint {url}",
-                err.msg,
+
+            error_message = (
+                f"Failed {method} from endpoint {urllib.parse.unquote(response.url)} due to "
+                f"being unable to decode response as JSON"
             )
+
+            logger.error(f"{error_message}. {err.msg}")
+
+            raise RequestFailed(response.status_code, response.reason, error_message, err.msg)
 
         return resp_json
 
-    def _get(self, api_endpoint: str, params: List[str] = None):
+    def _get(self, api_endpoint: str, params: list[str] = None):
         """Internal method to send a GET request to SuiteCRM
 
         This method makes a GET request to an API endpoint
@@ -668,7 +704,7 @@ class SuiteCRM:
         """
         return self._request("GET", self._get_url(api_endpoint), params=params)
 
-    def _post(self, api_endpoint: str, json=None):
+    def _post(self, api_endpoint: str, json: Any | None = None, headers: dict | None = None):
         """Internal method to send a POST request to SuiteCRM
 
         This method makes a GET request to an API endpoint
@@ -678,8 +714,10 @@ class SuiteCRM:
         ----------
         api_endpoint : str
             Endpoint to call (which will be added to the base URL)
-        data : dict, optional
-            Dictionary of data to set, default None.
+        json : Any, optional
+            A JSON serializable Python object to send in the body, default None.
+        headers : dict, optional
+            Additional headers to include in the request.
 
         Returns
         -------
@@ -691,9 +729,9 @@ class SuiteCRM:
         RequestFailed
             If the request failed for some reason.
         """
-        return self._request("POST", self._get_url(api_endpoint), json=json)
+        return self._request("POST", self._get_url(api_endpoint), json=json, headers=headers)
 
-    def _patch(self, api_endpoint, json=None):
+    def _patch(self, api_endpoint: str, json: Any | None = None, headers: dict | None = None):
         """Internal method to send a PATCH request to SuiteCRM
 
         This method makes a PATCH request to an API endpoint
@@ -703,8 +741,10 @@ class SuiteCRM:
         ----------
         api_endpoint : str
             Endpoint to call (which will be added to the base URL)
-        params : List[str]
-            Parameters to include in the request.
+        json : Any, optional
+            A JSON serializable Python object to send in the body, default None.
+        headers : dict, optional
+            Additional headers to include in the request.
 
         Returns
         -------
@@ -716,9 +756,9 @@ class SuiteCRM:
         RequestFailed
             If the request failed for some reason.
         """
-        return self._request("PATCH", self._get_url(api_endpoint), json=json)
+        return self._request("PATCH", self._get_url(api_endpoint), json=json, headers=headers)
 
-    def _delete(self, api_endpoint):
+    def _delete(self, api_endpoint, headers: dict | None = None):
         """Internal method to send a DELETE request to SuiteCRM
 
         This method makes a DELETE request to an API endpoint
@@ -728,6 +768,8 @@ class SuiteCRM:
         ----------
         api_endpoint : str
             Endpoint to call (which will be added to the base URL)
+        headers : dict, optional
+            Additional headers to include in the request.
 
         Returns
         -------
@@ -739,4 +781,4 @@ class SuiteCRM:
         RequestFailed
             If the request failed for some reason.
         """
-        return self._request("DELETE", self._get_url(api_endpoint))
+        return self._request("DELETE", self._get_url(api_endpoint), headers=headers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "libsuitecrm"
 description = "Library for interfacing with the SuiteCRM REST API focused on applications within IATI"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]
-version = "0.3.0"
+version = "0.4.0"
 requires-python = ">= 3.12.3"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import time
 
+import pymysql
 import pytest
 import urllib3
 from helpers import add_oauth_client_credentials, is_suitecrm_installed
@@ -55,7 +56,7 @@ def suitecrm_ready():
         if is_suitecrm_installed(SUITECRM_HTTP_URL):
             installed = True
 
-    if duration > TIMEOUT:
+    if not installed and duration > TIMEOUT:
         raise SuiteCrmReadyTimeout("SuiteCRM timed out; was not ready inside {duration} seconds")
 
     # Try to add OAuth client credentials to the SuiteCRM database.
@@ -65,8 +66,30 @@ def suitecrm_ready():
         raise err
 
 
-@pytest.fixture(scope="module")
-def crm(suitecrm_ready):
+@pytest.fixture(scope="function", autouse=True)
+def clear_tables_used_by_tests(suitecrm_ready) -> None:
+    """Fixture to clear tables used by tests before each test function"""
+    try:
+        connection = pymysql.connect(
+            host=DB_HOST,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            database=DB_NAME,
+            charset="utf8mb4",
+        )
+        with connection.cursor() as cursor:
+            cursor.execute("SET sql_safe_updates = 0")
+            cursor.execute("DELETE FROM accounts_cstm")
+            cursor.execute("DELETE FROM accounts_contacts")
+            cursor.execute("DELETE FROM accounts")
+            cursor.execute("DELETE FROM oauth2tokens")
+            connection.commit()
+    except Exception as err:
+        raise err
+
+
+@pytest.fixture()
+def crm(clear_tables_used_by_tests):
     """Fixture to wait for SuiteCRM to be available and then create a crm object with an access token"""
     urllib3.disable_warnings()
     _crm = libsuitecrm.SuiteCRM(SUITECRM_HTTPS_URL, client_id=CLIENT_ID, client_secret=CLIENT_SECRET, secure=False)

--- a/tests/integration/test_access_token.py
+++ b/tests/integration/test_access_token.py
@@ -73,10 +73,7 @@ def test_access_token_expiry(suitecrm_ready):
 
     # Wait for the token to expire then call the API.
     time.sleep(5)
-    try:
-        modules = crm.get_modules()
-        assert "Accounts" in modules["data"]["attributes"]
-    except Exception as err:
-        raise err
+    with pytest.raises(libsuitecrm.exceptions.RequestFailed) as exc_info:
+        crm.get_modules()
 
-    crm.logout()
+    assert exc_info.value.status_code == 401

--- a/tests/integration/test_crud.py
+++ b/tests/integration/test_crud.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import pytest
 from helpers import make_random_string
@@ -56,3 +57,92 @@ def test_create_with_id(crm):
 
     # Delete the created organisation.
     response = crm.delete_record("Account", new_id)
+
+
+@pytest.mark.parametrize("headers", [None, {"X-Custom-Header": "CustomValue"}])
+def test_create_custom_headers(crm, headers) -> None:
+
+    org_id = str(uuid.uuid4())
+    org_name = make_random_string(15)
+
+    crm._oauth_session = mock.MagicMock()
+
+    request_response = mock.MagicMock()
+    request_response.json.return_value = {
+        "data": {
+            "id": org_id,
+            "type": "Account",
+            "attributes": {"name": org_name},
+        }
+    }
+    crm._oauth_session.request.return_value = request_response
+
+    crm.create_record("Account", {"name": org_name, "id": org_id}, headers=headers)
+
+    crm._oauth_session.request.assert_called_with(
+        'POST',
+        mock.ANY,  # url
+        verify=mock.ANY,
+        params=mock.ANY,
+        json=mock.ANY,
+        headers=headers
+    )
+
+
+@pytest.mark.parametrize("headers", [None, {"X-Custom-Header": "CustomValue"}])
+def test_update_custom_headers(crm, headers) -> None:
+
+    org_id = str(uuid.uuid4())
+    org_name = make_random_string(15)
+
+    crm._oauth_session = mock.MagicMock()
+
+    request_response = mock.MagicMock()
+    request_response.json.return_value = {
+        "data": {
+            "id": org_id,
+            "type": "Account",
+            "attributes": {"name": org_name},
+        }
+    }
+    crm._oauth_session.request.return_value = request_response
+
+    crm.update_record("Account", org_id, {"name": org_name}, headers=headers)
+
+    crm._oauth_session.request.assert_called_with(
+        'PATCH',
+        mock.ANY,  # url
+        verify=mock.ANY,
+        params=mock.ANY,
+        json=mock.ANY,
+        headers=headers
+    )
+
+
+@pytest.mark.parametrize("headers", [None, {"X-Custom-Header": "CustomValue"}])
+def test_delete_custom_headers(crm, headers) -> None:
+
+    org_id = str(uuid.uuid4())
+    org_name = make_random_string(15)
+
+    crm._oauth_session = mock.MagicMock()
+
+    request_response = mock.MagicMock()
+    request_response.json.return_value = {
+        "meta":
+            {
+                "message": f"Record {org_id} is deleted"
+            }
+    }
+    crm._oauth_session.request.return_value = request_response
+
+    crm.delete_record("Account", org_id, headers=headers)
+
+    crm._oauth_session.request.assert_called_with(
+        'DELETE',
+        mock.ANY,  # url
+        verify=mock.ANY,
+        params=mock.ANY,
+        json=mock.ANY,
+        headers=headers
+    )

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -8,24 +8,24 @@ def test_get_record_failures(crm):
         crm.get_record_by_id("Account", "id-that-will-fail")
     assert exc_info.value.status_code == 400
 
-    id = crm.create_record("Account", {"name": "Org Name"})
-    assert isinstance(id, str)
+    record = crm.create_record("Account", {"name": "Org Name"})
+    assert isinstance(record["id"], str)
     with pytest.raises(libsuitecrm.exceptions.RequestFailed) as exc_info:
-        crm.get_record_by_id("Account", id, fields=["non_existant_field_name"])
+        crm.get_record_by_id("Account", record["id"], fields=["non_existant_field_name"])
     assert exc_info.value.status_code == 400
-    crm.delete_record("Account", id)
+    crm.delete_record("Account", record["id"])
 
 
 def test_get_multiple_records(crm):
-    ids = [crm.create_record("Account", {"name": x}) for x in ["A", "B", "C", "D", "E"]]
+    records = [crm.create_record("Account", {"name": x}) for x in ["A", "B", "C", "D", "E"]]
     response = crm.get_records("Accounts", fields=["name", "deleted"], sort_dir="ascending", sort_field="name")
 
     assert "data" in response
     assert isinstance(response["data"], list)
     for index, record in enumerate(response["data"]):
         assert record.get("type", "") == "Account"
-        assert record.get("id", "") == ids[index]
-    [crm.delete_record("Accounts", id) for id in ids]
+        assert record.get("id", "") == records[index]["id"]
+    [crm.delete_record("Accounts", record["id"]) for record in records]
 
 
 def test_filters(crm):
@@ -46,7 +46,7 @@ def test_filters(crm):
                 "billing_address_country": record["country"],
                 "description": record["description"],
             },
-        )
+        )["id"]
 
     response = crm.get_records(
         "Accounts",

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -1,72 +1,72 @@
 def test_relationships(crm):
-    contact1_id = crm.create_record("Contact", {"last_name": "Contact One"})
-    contact2_id = crm.create_record("Contact", {"last_name": "Contact Two"})
-    accounta_id = crm.create_record("Account", {"name": "Organisation A"})
-    accountb_id = crm.create_record("Account", {"name": "Organisation B"})
+    contact1 = crm.create_record("Contact", {"last_name": "Contact One"})
+    contact2 = crm.create_record("Contact", {"last_name": "Contact Two"})
+    accounta = crm.create_record("Account", {"name": "Organisation A"})
+    accountb = crm.create_record("Account", {"name": "Organisation B"})
 
     # Create relationship between contacts and accounts.  Organisation A has two
     # contacts, Organisation B has one contact.  We create the relationships
     # and then test that they are correct.
-    crm.create_relationship("Accounts", accounta_id, "contacts", "Contacts", contact1_id)
-    crm.create_relationship("Accounts", accounta_id, "contacts", "Contacts", contact2_id)
-    crm.create_relationship("Accounts", accountb_id, "contacts", "Contacts", contact1_id)
+    crm.create_relationship("Accounts", accounta["id"], "contacts", "Contacts", contact1["id"])
+    crm.create_relationship("Accounts", accounta["id"], "contacts", "Contacts", contact2["id"])
+    crm.create_relationship("Accounts", accountb["id"], "contacts", "Contacts", contact1["id"])
 
-    response = crm.get_relationship("Account", accounta_id, "contacts")
+    response = crm.get_relationship("Account", accounta["id"], "contacts")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 2
     assert "data" in response
     assert isinstance(response["data"], list)
     assert (
-        (response["data"][0]["id"] == contact1_id)
-        and (response["data"][1]["id"] == contact2_id)
-        or (response["data"][0]["id"] == contact2_id)
-        and (response["data"][1]["id"] == contact1_id)
+        (response["data"][0]["id"] == contact1["id"])
+        and (response["data"][1]["id"] == contact2["id"])
+        or (response["data"][0]["id"] == contact2["id"])
+        and (response["data"][1]["id"] == contact1["id"])
     )
 
-    response = crm.get_relationship("Account", accountb_id, "contacts")
+    response = crm.get_relationship("Account", accountb["id"], "contacts")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 1
     assert "data" in response
     assert isinstance(response["data"], list)
-    assert response["data"][0]["id"] == contact1_id
+    assert response["data"][0]["id"] == contact1["id"]
 
     # Test relationship between contacts and report_to in contacts, which has a more complicated link
     # field name (since the link field name for accounts and contacts is basically just the related
     # module name).  Create the relationship and check that it is correct when we get it.
-    crm.create_relationship("Contacts", contact2_id, "reports_to_link", "Contacts", contact1_id)
+    crm.create_relationship("Contacts", contact2["id"], "reports_to_link", "Contacts", contact1["id"])
 
-    response = crm.get_relationship("Contacts", contact2_id, "reports_to_link")
+    response = crm.get_relationship("Contacts", contact2["id"], "reports_to_link")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 1
     assert "data" in response
     assert isinstance(response["data"], list)
-    assert response["data"][0]["id"] == contact1_id
+    assert response["data"][0]["id"] == contact1["id"]
 
     # Remove relationships - each time we check that the relationships are as we expect.
-    crm.delete_relationship("Contacts", contact2_id, "reports_to_link", contact1_id)
-    response = crm.get_relationship("Contacts", contact2_id, "reports_to_link")
+    crm.delete_relationship("Contacts", contact2["id"], "reports_to_link", contact1["id"])
+    response = crm.get_relationship("Contacts", contact2["id"], "reports_to_link")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 0
 
-    crm.delete_relationship("Account", accountb_id, "contacts", contact1_id)
-    response = crm.get_relationship("Account", accountb_id, "contacts")
+    crm.delete_relationship("Account", accountb["id"], "contacts", contact1["id"])
+    response = crm.get_relationship("Account", accountb["id"], "contacts")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 0
 
-    crm.delete_relationship("Account", accounta_id, "contacts", contact2_id)
-    response = crm.get_relationship("Account", accounta_id, "contacts")
+    crm.delete_relationship("Account", accounta["id"], "contacts", contact2["id"])
+    response = crm.get_relationship("Account", accounta["id"], "contacts")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 1
     assert "data" in response
     assert isinstance(response["data"], list)
-    assert response["data"][0]["id"] == contact1_id
+    assert response["data"][0]["id"] == contact1["id"]
 
-    crm.delete_relationship("Account", accounta_id, "contacts", contact1_id)
-    response = crm.get_relationship("Account", accounta_id, "contacts")
+    crm.delete_relationship("Account", accounta["id"], "contacts", contact1["id"])
+    response = crm.get_relationship("Account", accounta["id"], "contacts")
     assert "meta" in response
     assert response["meta"].get("total-records", 0) == 0
 
-    crm.delete_record("Contact", contact1_id)
-    crm.delete_record("Contact", contact2_id)
-    crm.delete_record("Account", accounta_id)
-    crm.delete_record("Account", accountb_id)
+    crm.delete_record("Contact", contact1["id"])
+    crm.delete_record("Contact", contact2["id"])
+    crm.delete_record("Account", accounta["id"])
+    crm.delete_record("Account", accountb["id"])


### PR DESCRIPTION
This PR:
* Updates the test infrastructure and tests to be passing (not all tests were passing)
* Adds tests for the sending custom header functionality
* Alters `crm.py` to allow the sending of custom headers to SuiteCRM for write-requests