### PR TITLE
Workaround the over-zealous character escaping in SuiteCRM API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip-compile --all-build-deps --strip-extras
 
 ### Testing
 
-Pytest is used for unit and integration testing of the library.  Most of the testing is an integration test that runs using a local instance of SuiteCRM.  At the moment the local instance must be manually started.  Because this needs to be tested against the IATI fork of SuiteCRM the docker setup has now been removed from this repository.  To test, spin up the test instance from [IATI SuiteCRM](https://github.com/IATI/iati-suitecrm) with ```docker compose up --build``` and then run the tests:
+Pytest is used for unit and integration testing of the library.  Most of the testing is an integration test that runs using a local instance of SuiteCRM.  At the moment the local instance must be manually started.  Because this needs to be tested against the IATI fork of SuiteCRM the docker setup has now been removed from this repository.  To test, spin up the test instance from [IATI SuiteCRM](https://github.com/IATI/iati-suitecrm) with ```docker compose up --build``` (run this command from the `dev` directory in that repo) and then run the tests:
 
 ```
 pytest

--- a/libsuitecrm/crm.py
+++ b/libsuitecrm/crm.py
@@ -105,6 +105,52 @@ class SuiteCRM:
         """
         return self._api_base + self._api_base_path + path
 
+    def _add_paging_params(self, params: list[tuple[str, str]], page_number: int, page_size: int) -> None:
+        """Internal method to add paging parameters to a list of parameters
+
+        Parameters
+        ----------
+        params : list[tuple[str, str]]
+            List of parameters to add to.
+        page_number : int
+            Page number to add.
+        page_size : int
+            Page size to add.
+
+        Returns
+        -------
+        None
+        """
+        if page_number is not None and page_size is not None:
+            params.append(("page[number]", page_number))
+            params.append(("page[size]", page_size))
+
+    def _add_sorting_params(self, params: list[tuple[str, str]], sort_dir: str, sort_field: str) -> None:
+        """Internal method to add sorting parameters to a list of parameters
+
+        Parameters
+        ----------
+        params : list[tuple[str, str]]
+            List of parameters to add to.
+        sort_dir : str
+            Sort direction to add.
+        sort_field : str
+            Sort field to add.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If sort direction is invalid.
+        """
+        if sort_field is not None:
+            if not (sort_dir == "ascending" or sort_dir == "descending"):
+                raise ValueError("Sort direction must be either ascending or descending")
+            params.append(("sort", ("-" if sort_dir == "descending" else "") + sort_field))
+
     def export_access_token(self) -> dict[str, Any] | None:
         """Export the current access token as a dictionary
 
@@ -302,13 +348,11 @@ class SuiteCRM:
         params = []
         if fields is not None:
             params += _format_fields(module_name, fields)
-        if page_number is not None and page_size is not None:
-            params.append(("page[number]", page_number))
-            params.append(("page[size]", page_size))
-        if sort_field is not None:
-            if not (sort_dir == "ascending" or sort_dir == "descending"):
-                raise ValueError("Sort direction must be either ascending or descending")
-            params.append(("sort", ("-" if sort_dir == "descending" else "") + sort_field))
+
+        self._add_paging_params(params, page_number, page_size)
+
+        self._add_sorting_params(params, sort_dir, sort_field)
+
         if filters is not None:
             [params.append(x) for x in filters.operations]
 
@@ -547,7 +591,16 @@ class SuiteCRM:
             logger.error(f"Attempt to create relationship failed: '{response["meta"]["message"]}'")
             raise CreateRelationshipFailed("Cannot understand response from server")
 
-    def get_relationship(self, module_name: str, id: str, link_field_name: str):
+    def get_relationship(
+        self,
+        module_name: str,
+        id: str,
+        link_field_name: str,
+        page_number: int = None,
+        page_size: int = None,
+        sort_dir: str = "ascending",
+        sort_field: str = None,
+    ):
         """Get relationships between a record in one module with another module
 
         Calls the endpoint documented at:
@@ -561,8 +614,25 @@ class SuiteCRM:
             ID of the record to get the relationship from.
         link_field_name : str
             Link field name to get the relationships.
+        page_number : int, optional
+            Page number to return, when page_size is not None, by default None.
+        page_size : int, optional
+            Number of records per page, when page_number is not None, by default None.
+        sort_dir : str, optional
+            Search direction, "ascending" or "descending", by default "ascending".
+        sort_field : str, optional
+            Field to sort on, by default None.
         """
-        response = self._get(f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}")
+        params = []
+
+        self._add_paging_params(params, page_number, page_size)
+
+        self._add_sorting_params(params, sort_dir, sort_field)
+
+        response = self._get(
+            f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}", params=params
+        )
+
         return response
 
     def delete_relationship(

--- a/libsuitecrm/crm.py
+++ b/libsuitecrm/crm.py
@@ -702,7 +702,12 @@ class SuiteCRM:
         RequestFailed
             If the request failed for some reason.
         """
-        return self._request("GET", self._get_url(api_endpoint), params=params)
+        response = self._request("GET", self._get_url(api_endpoint), params=params)
+
+        if "data" in response and "attributes" in response["data"]:
+            self._fix_escaped_chars_in_response(response["data"]["attributes"])
+
+        return response
 
     def _post(self, api_endpoint: str, json: Any | None = None, headers: dict | None = None):
         """Internal method to send a POST request to SuiteCRM
@@ -782,3 +787,37 @@ class SuiteCRM:
             If the request failed for some reason.
         """
         return self._request("DELETE", self._get_url(api_endpoint), headers=headers)
+
+    def _fix_escaped_chars_in_response(self, response_data: dict | list):
+        """Internal method to fix escaped HTML characters in SuiteCRM response in-place
+
+        Parameters
+        ----------
+        response_data : dict | list
+            Response or part of response data from SuiteCRM.
+
+        Returns
+        -------
+        None
+        """
+
+        def _iter_kv(obj):
+            if isinstance(obj, dict):
+                return obj.items()
+            else:
+                return enumerate(obj)
+
+        def _fix_escaped_string(s: str) -> str:
+            return (
+                s.replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&quot;", '"')
+                .replace("&#39;", "'")
+                .replace("&#039;", "'")
+            )
+
+        for index_key, item in _iter_kv(response_data):
+            if isinstance(item, str):
+                response_data[index_key] = _fix_escaped_string(item)
+            elif isinstance(item, dict) or isinstance(item, list):
+                self._fix_escaped_chars_in_response(response_data[index_key])

--- a/libsuitecrm/crm.py
+++ b/libsuitecrm/crm.py
@@ -600,6 +600,7 @@ class SuiteCRM:
         page_size: int = None,
         sort_dir: str = "ascending",
         sort_field: str = None,
+        filters: Filter = None,
     ):
         """Get relationships between a record in one module with another module
 
@@ -628,6 +629,9 @@ class SuiteCRM:
         self._add_paging_params(params, page_number, page_size)
 
         self._add_sorting_params(params, sort_dir, sort_field)
+
+        if filters is not None:
+            [params.append(x) for x in filters.operations]
 
         response = self._get(
             f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}", params=params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "libsuitecrm"
 description = "Library for interfacing with the SuiteCRM REST API focused on applications within IATI"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">= 3.12.3"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "libsuitecrm"
 description = "Library for interfacing with the SuiteCRM REST API focused on applications within IATI"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]
-version = "0.4.1"
+version = "0.5.0"
 requires-python = ">= 3.12.3"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/integration/test_access_token.py
+++ b/tests/integration/test_access_token.py
@@ -72,7 +72,7 @@ def test_access_token_expiry(suitecrm_ready):
         raise err
 
     # Wait for the token to expire then call the API.
-    time.sleep(5)
+    time.sleep(2)
     with pytest.raises(libsuitecrm.exceptions.RequestFailed) as exc_info:
         crm.get_modules()
 

--- a/tests/integration/test_crud.py
+++ b/tests/integration/test_crud.py
@@ -113,7 +113,6 @@ def test_update_custom_headers(crm, headers) -> None:
 def test_delete_custom_headers(crm, headers) -> None:
 
     org_id = str(uuid.uuid4())
-    org_name = make_random_string(15)
 
     crm._oauth_session = mock.MagicMock()
 

--- a/tests/integration/test_crud.py
+++ b/tests/integration/test_crud.py
@@ -80,12 +80,7 @@ def test_create_custom_headers(crm, headers) -> None:
     crm.create_record("Account", {"name": org_name, "id": org_id}, headers=headers)
 
     crm._oauth_session.request.assert_called_with(
-        'POST',
-        mock.ANY,  # url
-        verify=mock.ANY,
-        params=mock.ANY,
-        json=mock.ANY,
-        headers=headers
+        "POST", mock.ANY, verify=mock.ANY, params=mock.ANY, json=mock.ANY, headers=headers  # url
     )
 
 
@@ -110,12 +105,7 @@ def test_update_custom_headers(crm, headers) -> None:
     crm.update_record("Account", org_id, {"name": org_name}, headers=headers)
 
     crm._oauth_session.request.assert_called_with(
-        'PATCH',
-        mock.ANY,  # url
-        verify=mock.ANY,
-        params=mock.ANY,
-        json=mock.ANY,
-        headers=headers
+        "PATCH", mock.ANY, verify=mock.ANY, params=mock.ANY, json=mock.ANY, headers=headers  # url
     )
 
 
@@ -128,21 +118,11 @@ def test_delete_custom_headers(crm, headers) -> None:
     crm._oauth_session = mock.MagicMock()
 
     request_response = mock.MagicMock()
-    request_response.json.return_value = {
-        "meta":
-            {
-                "message": f"Record {org_id} is deleted"
-            }
-    }
+    request_response.json.return_value = {"meta": {"message": f"Record {org_id} is deleted"}}
     crm._oauth_session.request.return_value = request_response
 
     crm.delete_record("Account", org_id, headers=headers)
 
     crm._oauth_session.request.assert_called_with(
-        'DELETE',
-        mock.ANY,  # url
-        verify=mock.ANY,
-        params=mock.ANY,
-        json=mock.ANY,
-        headers=headers
+        "DELETE", mock.ANY, verify=mock.ANY, params=mock.ANY, json=mock.ANY, headers=headers  # url
     )

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -92,9 +92,9 @@ def test_get_content_with_html_chars(crm):
         "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"],
     }
 
-    contact_payload = {field: test_str for field in fields_to_check_by_module["Accounts"]}
+    account_payload = {field: test_str for field in fields_to_check_by_module["Accounts"]}
 
-    account = crm.create_record("Accounts", contact_payload)
+    account = crm.create_record("Accounts", account_payload)
 
     contact_payload = {field: test_str for field in fields_to_check_by_module["Contacts"]}
 

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -81,3 +81,44 @@ def test_filters(crm):
     assert response["data"][0]["id"] == test_records[5]["id"]
 
     [crm.delete_record("Accounts", record["id"]) for record in test_records]
+
+
+def test_get_content_with_html_chars(crm):
+    test_str = 'Test special chars: <, >, &, ", \''
+
+    fields_to_check_by_module = {
+        "Accounts": ["description", "name", "website"],
+        "Contacts": ["account_name", "iati_inperson_name", "iati_online_name", "name"],
+        "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"]
+    }
+
+    contact_payload = { field: test_str for field in fields_to_check_by_module["Accounts"] }
+
+    account = crm.create_record("Accounts", contact_payload)
+
+    contact_payload = { field: test_str for field in fields_to_check_by_module["Contacts"] }
+
+    contact = crm.create_record("Contacts", contact_payload)
+
+    crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])
+
+    dataset_payload = { field: test_str for field in fields_to_check_by_module["IATI_Datasets"] }
+
+    dataset = crm.create_record("IATI_Datasets", dataset_payload)
+
+    crm.create_relationship("Accounts", account["id"], "account_iati_datasets", "IATI_Datasets", dataset["id"])
+
+    crm.create_relationship("IATI_Datasets", dataset["id"], "iati_dataset_creator_person_link", "Contacts", contact["id"])
+
+    for module, id in zip(fields_to_check_by_module.keys(), [account["id"], contact["id"], dataset["id"]]):
+        fields = fields_to_check_by_module[module]
+
+        fetched_record = crm.get_record_by_id(module, id, fields=fields)
+
+        for field in fields:
+            assert field in fetched_record["data"]["attributes"]
+            assert fetched_record["data"]["attributes"][field] == test_str
+
+    crm.delete_record("Accounts", account["id"])
+    crm.delete_record("Contacts", contact["id"])
+    crm.delete_record("IATI_Datasets", dataset["id"])

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -88,8 +88,8 @@ def test_get_content_with_html_chars(crm):
 
     fields_to_check_by_module = {
         "Accounts": ["description", "name", "website"],
-        "Contacts": ["account_name", "iati_inperson_name", "iati_online_name", "name"],
-        "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"]
+        "Contacts": ["account_name", "iati_inperson_name", "iati_online_name"],
+        "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"],
     }
 
     contact_payload = { field: test_str for field in fields_to_check_by_module["Accounts"] }

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -84,7 +84,7 @@ def test_filters(crm):
 
 
 def test_get_content_with_html_chars(crm):
-    test_str = 'Test special chars: <, >, &, ", \''
+    test_str = "Test special chars: <, >, &, \", '"
 
     fields_to_check_by_module = {
         "Accounts": ["description", "name", "website"],
@@ -92,23 +92,25 @@ def test_get_content_with_html_chars(crm):
         "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"],
     }
 
-    contact_payload = { field: test_str for field in fields_to_check_by_module["Accounts"] }
+    contact_payload = {field: test_str for field in fields_to_check_by_module["Accounts"]}
 
     account = crm.create_record("Accounts", contact_payload)
 
-    contact_payload = { field: test_str for field in fields_to_check_by_module["Contacts"] }
+    contact_payload = {field: test_str for field in fields_to_check_by_module["Contacts"]}
 
     contact = crm.create_record("Contacts", contact_payload)
 
     crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])
 
-    dataset_payload = { field: test_str for field in fields_to_check_by_module["IATI_Datasets"] }
+    dataset_payload = {field: test_str for field in fields_to_check_by_module["IATI_Datasets"]}
 
     dataset = crm.create_record("IATI_Datasets", dataset_payload)
 
     crm.create_relationship("Accounts", account["id"], "account_iati_datasets", "IATI_Datasets", dataset["id"])
 
-    crm.create_relationship("IATI_Datasets", dataset["id"], "iati_dataset_creator_person_link", "Contacts", contact["id"])
+    crm.create_relationship(
+        "IATI_Datasets", dataset["id"], "iati_dataset_creator_person_link", "Contacts", contact["id"]
+    )
 
     for module, id in zip(fields_to_check_by_module.keys(), [account["id"], contact["id"], dataset["id"]]):
         fields = fields_to_check_by_module[module]

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -1,3 +1,6 @@
+from libsuitecrm import Filter
+
+
 def test_relationships(crm):
     contact1 = crm.create_record("Contact", {"last_name": "Contact One"})
     contact2 = crm.create_record("Contact", {"last_name": "Contact Two"})
@@ -131,5 +134,23 @@ def test_get_relationships_sorting(crm):
         sort_dir="descending",
     )
     assert relationships["data"][0]["attributes"]["last_name"] == "Contact 9"
+
+    _delete_records(crm, [account] + contacts)
+
+
+def test_get_relationships_filtering(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    relationships = crm.get_relationship(
+        "Contacts", contacts[0]["id"], "Accounts", filters=Filter().equal("name", "Organisation 1")
+    )
+
+    assert len(relationships["data"]) == 1
+
+    relationships = crm.get_relationship(
+        "Contacts", contacts[0]["id"], "Accounts", filters=Filter().equal("name", "Organisation Unknown")
+    )
+
+    assert len(relationships["data"]) == 0
 
     _delete_records(crm, [account] + contacts)

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -70,3 +70,66 @@ def test_relationships(crm):
     crm.delete_record("Contact", contact2["id"])
     crm.delete_record("Account", accounta["id"])
     crm.delete_record("Account", accountb["id"])
+
+
+def _create_account_contacts_and_relationships(crm, num_contacts: int):
+    contacts: dict = []
+    for contact_idx in range(1, num_contacts + 1):
+        contact = crm.create_record("Contact", {"last_name": f"Contact {contact_idx}"})
+        contacts.append(contact)
+
+    account = crm.create_record("Account", {"name": f"Organisation 1"})
+
+    for contact in contacts:
+        crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])
+
+    return account, contacts
+
+
+def _delete_records(crm, records):
+    for record in records:
+        crm.delete_record(record["type"], record["id"])
+
+
+def test_get_relationships_paging_returns_correct_num(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    for page_size in [None, 3, 4, 5]:
+        relationships = crm.get_relationship("Accounts", account["id"], "contacts", page_size=page_size, page_number=1)
+        assert len(relationships["data"]) == 9 if page_size is None else page_size
+
+    _delete_records(crm, [account] + contacts)
+
+
+def test_get_relationships_paging_returns_correct_content(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    relationships = crm.get_relationship(
+        "Accounts", account["id"], "contacts", page_size=2, page_number=3, sort_field="last_name", sort_dir="ascending"
+    )
+    assert relationships["data"][0]["attributes"]["last_name"] == "Contact 5"
+    assert relationships["data"][1]["attributes"]["last_name"] == "Contact 6"
+
+    _delete_records(crm, [account] + contacts)
+
+
+def test_get_relationships_sorting(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    relationships = crm.get_relationship(
+        "Accounts", account["id"], "contacts", page_size=1, page_number=1, sort_field="last_name", sort_dir="ascending"
+    )
+    assert relationships["data"][0]["attributes"]["last_name"] == "Contact 1"
+
+    relationships = crm.get_relationship(
+        "Accounts",
+        account["id"],
+        "contacts",
+        page_size=1,
+        page_number=1,
+        sort_field="last_name",
+        sort_dir="descending",
+    )
+    assert relationships["data"][0]["attributes"]["last_name"] == "Contact 9"
+
+    _delete_records(crm, [account] + contacts)

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -78,7 +78,7 @@ def _create_account_contacts_and_relationships(crm, num_contacts: int):
         contact = crm.create_record("Contact", {"last_name": f"Contact {contact_idx}"})
         contacts.append(contact)
 
-    account = crm.create_record("Account", {"name": f"Organisation 1"})
+    account = crm.create_record("Account", {"name": "Organisation 1"})
 
     for contact in contacts:
         crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])

--- a/tests/test_fix_suitecrm_escaping.py
+++ b/tests/test_fix_suitecrm_escaping.py
@@ -1,0 +1,28 @@
+import pytest
+
+from libsuitecrm import SuiteCRM
+
+
+@pytest.mark.parametrize("input,expected", [
+    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'},
+     {"str": 'SuiteCRM mishandles: <, >, \', \', "'}],
+    [['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'], ['SuiteCRM mishandles: <, >, \', \', "']],
+    [['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
+      'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'],
+     ['SuiteCRM mishandles: <, >, \', \', "', 'SuiteCRM mishandles: <, >, \', \', "']],
+    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
+      "sublist": ['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;']},
+      {"str": 'SuiteCRM mishandles: <, >, \', \', "',
+       "sublist": ['SuiteCRM mishandles: <, >, \', \', "']}],
+    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
+      "subdict": {"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'}},
+      {"str": 'SuiteCRM mishandles: <, >, \', \', "',
+       "subdict": {"str": 'SuiteCRM mishandles: <, >, \', \', "'}}],
+])
+def test_fix_escaped_characters(input, expected):
+
+    crm = SuiteCRM(api_base_url="dummy_url", client_id="dummy", client_secret="dummy", secure=False)
+
+    crm._fix_escaped_chars_in_response(input)
+
+    assert input == expected

--- a/tests/test_fix_suitecrm_escaping.py
+++ b/tests/test_fix_suitecrm_escaping.py
@@ -3,22 +3,37 @@ import pytest
 from libsuitecrm import SuiteCRM
 
 
-@pytest.mark.parametrize("input,expected", [
-    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'},
-     {"str": 'SuiteCRM mishandles: <, >, \', \', "'}],
-    [['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'], ['SuiteCRM mishandles: <, >, \', \', "']],
-    [['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
-      'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'],
-     ['SuiteCRM mishandles: <, >, \', \', "', 'SuiteCRM mishandles: <, >, \', \', "']],
-    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
-      "sublist": ['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;']},
-      {"str": 'SuiteCRM mishandles: <, >, \', \', "',
-       "sublist": ['SuiteCRM mishandles: <, >, \', \', "']}],
-    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
-      "subdict": {"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'}},
-      {"str": 'SuiteCRM mishandles: <, >, \', \', "',
-       "subdict": {"str": 'SuiteCRM mishandles: <, >, \', \', "'}}],
-])
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        [
+            {"str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"},
+            {"str": "SuiteCRM mishandles: <, >, ', ', \""},
+        ],
+        [["SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"], ["SuiteCRM mishandles: <, >, ', ', \""]],
+        [
+            [
+                "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+                "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+            ],
+            ["SuiteCRM mishandles: <, >, ', ', \"", "SuiteCRM mishandles: <, >, ', ', \""],
+        ],
+        [
+            {
+                "str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+                "sublist": ["SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"],
+            },
+            {"str": "SuiteCRM mishandles: <, >, ', ', \"", "sublist": ["SuiteCRM mishandles: <, >, ', ', \""]},
+        ],
+        [
+            {
+                "str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+                "subdict": {"str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"},
+            },
+            {"str": "SuiteCRM mishandles: <, >, ', ', \"", "subdict": {"str": "SuiteCRM mishandles: <, >, ', ', \""}},
+        ],
+    ],
+)
 def test_fix_escaped_characters(input, expected):
 
     crm = SuiteCRM(api_base_url="dummy_url", client_id="dummy", client_secret="dummy", secure=False)


### PR DESCRIPTION
SuiteCRM escapes four of the five characters that must be escaped in XML/HTML in the output of its JSON-based REST API. This PR works around that SuiteCRM bug.