### PR TITLE
Add paging, sorting and filtering to `get_relationship()`

### DIFF
--- a/libsuitecrm/crm.py
+++ b/libsuitecrm/crm.py
@@ -105,6 +105,52 @@ class SuiteCRM:
         """
         return self._api_base + self._api_base_path + path
 
+    def _add_paging_params(self, params: list[tuple[str, str]], page_number: int, page_size: int) -> None:
+        """Internal method to add paging parameters to a list of parameters
+
+        Parameters
+        ----------
+        params : list[tuple[str, str]]
+            List of parameters to add to.
+        page_number : int
+            Page number to add.
+        page_size : int
+            Page size to add.
+
+        Returns
+        -------
+        None
+        """
+        if page_number is not None and page_size is not None:
+            params.append(("page[number]", page_number))
+            params.append(("page[size]", page_size))
+
+    def _add_sorting_params(self, params: list[tuple[str, str]], sort_dir: str, sort_field: str) -> None:
+        """Internal method to add sorting parameters to a list of parameters
+
+        Parameters
+        ----------
+        params : list[tuple[str, str]]
+            List of parameters to add to.
+        sort_dir : str
+            Sort direction to add.
+        sort_field : str
+            Sort field to add.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If sort direction is invalid.
+        """
+        if sort_field is not None:
+            if not (sort_dir == "ascending" or sort_dir == "descending"):
+                raise ValueError("Sort direction must be either ascending or descending")
+            params.append(("sort", ("-" if sort_dir == "descending" else "") + sort_field))
+
     def export_access_token(self) -> dict[str, Any] | None:
         """Export the current access token as a dictionary
 
@@ -302,13 +348,11 @@ class SuiteCRM:
         params = []
         if fields is not None:
             params += _format_fields(module_name, fields)
-        if page_number is not None and page_size is not None:
-            params.append(("page[number]", page_number))
-            params.append(("page[size]", page_size))
-        if sort_field is not None:
-            if not (sort_dir == "ascending" or sort_dir == "descending"):
-                raise ValueError("Sort direction must be either ascending or descending")
-            params.append(("sort", ("-" if sort_dir == "descending" else "") + sort_field))
+
+        self._add_paging_params(params, page_number, page_size)
+
+        self._add_sorting_params(params, sort_dir, sort_field)
+
         if filters is not None:
             [params.append(x) for x in filters.operations]
 
@@ -547,7 +591,16 @@ class SuiteCRM:
             logger.error(f"Attempt to create relationship failed: '{response["meta"]["message"]}'")
             raise CreateRelationshipFailed("Cannot understand response from server")
 
-    def get_relationship(self, module_name: str, id: str, link_field_name: str):
+    def get_relationship(
+        self,
+        module_name: str,
+        id: str,
+        link_field_name: str,
+        page_number: int = None,
+        page_size: int = None,
+        sort_dir: str = "ascending",
+        sort_field: str = None,
+    ):
         """Get relationships between a record in one module with another module
 
         Calls the endpoint documented at:
@@ -561,8 +614,25 @@ class SuiteCRM:
             ID of the record to get the relationship from.
         link_field_name : str
             Link field name to get the relationships.
+        page_number : int, optional
+            Page number to return, when page_size is not None, by default None.
+        page_size : int, optional
+            Number of records per page, when page_number is not None, by default None.
+        sort_dir : str, optional
+            Search direction, "ascending" or "descending", by default "ascending".
+        sort_field : str, optional
+            Field to sort on, by default None.
         """
-        response = self._get(f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}")
+        params = []
+
+        self._add_paging_params(params, page_number, page_size)
+
+        self._add_sorting_params(params, sort_dir, sort_field)
+
+        response = self._get(
+            f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}", params=params
+        )
+
         return response
 
     def delete_relationship(

--- a/libsuitecrm/crm.py
+++ b/libsuitecrm/crm.py
@@ -600,6 +600,7 @@ class SuiteCRM:
         page_size: int = None,
         sort_dir: str = "ascending",
         sort_field: str = None,
+        filters: Filter = None,
     ):
         """Get relationships between a record in one module with another module
 
@@ -628,6 +629,9 @@ class SuiteCRM:
         self._add_paging_params(params, page_number, page_size)
 
         self._add_sorting_params(params, sort_dir, sort_field)
+
+        if filters is not None:
+            [params.append(x) for x in filters.operations]
 
         response = self._get(
             f"/Api/V8/module/{module_name}/{id}/relationships/{link_field_name.lower()}", params=params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "libsuitecrm"
 description = "Library for interfacing with the SuiteCRM REST API focused on applications within IATI"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]
-version = "0.4.1"
+version = "0.5.0"
 requires-python = ">= 3.12.3"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/integration/test_crud.py
+++ b/tests/integration/test_crud.py
@@ -113,7 +113,6 @@ def test_update_custom_headers(crm, headers) -> None:
 def test_delete_custom_headers(crm, headers) -> None:
 
     org_id = str(uuid.uuid4())
-    org_name = make_random_string(15)
 
     crm._oauth_session = mock.MagicMock()
 

--- a/tests/integration/test_crud.py
+++ b/tests/integration/test_crud.py
@@ -80,12 +80,7 @@ def test_create_custom_headers(crm, headers) -> None:
     crm.create_record("Account", {"name": org_name, "id": org_id}, headers=headers)
 
     crm._oauth_session.request.assert_called_with(
-        'POST',
-        mock.ANY,  # url
-        verify=mock.ANY,
-        params=mock.ANY,
-        json=mock.ANY,
-        headers=headers
+        "POST", mock.ANY, verify=mock.ANY, params=mock.ANY, json=mock.ANY, headers=headers  # url
     )
 
 
@@ -110,12 +105,7 @@ def test_update_custom_headers(crm, headers) -> None:
     crm.update_record("Account", org_id, {"name": org_name}, headers=headers)
 
     crm._oauth_session.request.assert_called_with(
-        'PATCH',
-        mock.ANY,  # url
-        verify=mock.ANY,
-        params=mock.ANY,
-        json=mock.ANY,
-        headers=headers
+        "PATCH", mock.ANY, verify=mock.ANY, params=mock.ANY, json=mock.ANY, headers=headers  # url
     )
 
 
@@ -128,21 +118,11 @@ def test_delete_custom_headers(crm, headers) -> None:
     crm._oauth_session = mock.MagicMock()
 
     request_response = mock.MagicMock()
-    request_response.json.return_value = {
-        "meta":
-            {
-                "message": f"Record {org_id} is deleted"
-            }
-    }
+    request_response.json.return_value = {"meta": {"message": f"Record {org_id} is deleted"}}
     crm._oauth_session.request.return_value = request_response
 
     crm.delete_record("Account", org_id, headers=headers)
 
     crm._oauth_session.request.assert_called_with(
-        'DELETE',
-        mock.ANY,  # url
-        verify=mock.ANY,
-        params=mock.ANY,
-        json=mock.ANY,
-        headers=headers
+        "DELETE", mock.ANY, verify=mock.ANY, params=mock.ANY, json=mock.ANY, headers=headers  # url
     )

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -88,8 +88,8 @@ def test_get_content_with_html_chars(crm):
 
     fields_to_check_by_module = {
         "Accounts": ["description", "name", "website"],
-        "Contacts": ["account_name", "iati_inperson_name", "iati_online_name", "name"],
-        "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"]
+        "Contacts": ["account_name", "iati_inperson_name", "iati_online_name"],
+        "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"],
     }
 
     contact_payload = { field: test_str for field in fields_to_check_by_module["Accounts"] }

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -84,7 +84,7 @@ def test_filters(crm):
 
 
 def test_get_content_with_html_chars(crm):
-    test_str = 'Test special chars: <, >, &, ", \''
+    test_str = "Test special chars: <, >, &, \", '"
 
     fields_to_check_by_module = {
         "Accounts": ["description", "name", "website"],
@@ -92,23 +92,25 @@ def test_get_content_with_html_chars(crm):
         "IATI_Datasets": ["description", "iati_dataset_url", "iati_dataset_owner_org_name", "name"],
     }
 
-    contact_payload = { field: test_str for field in fields_to_check_by_module["Accounts"] }
+    contact_payload = {field: test_str for field in fields_to_check_by_module["Accounts"]}
 
     account = crm.create_record("Accounts", contact_payload)
 
-    contact_payload = { field: test_str for field in fields_to_check_by_module["Contacts"] }
+    contact_payload = {field: test_str for field in fields_to_check_by_module["Contacts"]}
 
     contact = crm.create_record("Contacts", contact_payload)
 
     crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])
 
-    dataset_payload = { field: test_str for field in fields_to_check_by_module["IATI_Datasets"] }
+    dataset_payload = {field: test_str for field in fields_to_check_by_module["IATI_Datasets"]}
 
     dataset = crm.create_record("IATI_Datasets", dataset_payload)
 
     crm.create_relationship("Accounts", account["id"], "account_iati_datasets", "IATI_Datasets", dataset["id"])
 
-    crm.create_relationship("IATI_Datasets", dataset["id"], "iati_dataset_creator_person_link", "Contacts", contact["id"])
+    crm.create_relationship(
+        "IATI_Datasets", dataset["id"], "iati_dataset_creator_person_link", "Contacts", contact["id"]
+    )
 
     for module, id in zip(fields_to_check_by_module.keys(), [account["id"], contact["id"], dataset["id"]]):
         fields = fields_to_check_by_module[module]

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -1,3 +1,6 @@
+from libsuitecrm import Filter
+
+
 def test_relationships(crm):
     contact1 = crm.create_record("Contact", {"last_name": "Contact One"})
     contact2 = crm.create_record("Contact", {"last_name": "Contact Two"})
@@ -131,5 +134,23 @@ def test_get_relationships_sorting(crm):
         sort_dir="descending",
     )
     assert relationships["data"][0]["attributes"]["last_name"] == "Contact 9"
+
+    _delete_records(crm, [account] + contacts)
+
+
+def test_get_relationships_filtering(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    relationships = crm.get_relationship(
+        "Contacts", contacts[0]["id"], "Accounts", filters=Filter().equal("name", "Organisation 1")
+    )
+
+    assert len(relationships["data"]) == 1
+
+    relationships = crm.get_relationship(
+        "Contacts", contacts[0]["id"], "Accounts", filters=Filter().equal("name", "Organisation Unknown")
+    )
+
+    assert len(relationships["data"]) == 0
 
     _delete_records(crm, [account] + contacts)

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -70,3 +70,66 @@ def test_relationships(crm):
     crm.delete_record("Contact", contact2["id"])
     crm.delete_record("Account", accounta["id"])
     crm.delete_record("Account", accountb["id"])
+
+
+def _create_account_contacts_and_relationships(crm, num_contacts: int):
+    contacts: dict = []
+    for contact_idx in range(1, num_contacts + 1):
+        contact = crm.create_record("Contact", {"last_name": f"Contact {contact_idx}"})
+        contacts.append(contact)
+
+    account = crm.create_record("Account", {"name": f"Organisation 1"})
+
+    for contact in contacts:
+        crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])
+
+    return account, contacts
+
+
+def _delete_records(crm, records):
+    for record in records:
+        crm.delete_record(record["type"], record["id"])
+
+
+def test_get_relationships_paging_returns_correct_num(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    for page_size in [None, 3, 4, 5]:
+        relationships = crm.get_relationship("Accounts", account["id"], "contacts", page_size=page_size, page_number=1)
+        assert len(relationships["data"]) == 9 if page_size is None else page_size
+
+    _delete_records(crm, [account] + contacts)
+
+
+def test_get_relationships_paging_returns_correct_content(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    relationships = crm.get_relationship(
+        "Accounts", account["id"], "contacts", page_size=2, page_number=3, sort_field="last_name", sort_dir="ascending"
+    )
+    assert relationships["data"][0]["attributes"]["last_name"] == "Contact 5"
+    assert relationships["data"][1]["attributes"]["last_name"] == "Contact 6"
+
+    _delete_records(crm, [account] + contacts)
+
+
+def test_get_relationships_sorting(crm):
+    account, contacts = _create_account_contacts_and_relationships(crm, 9)
+
+    relationships = crm.get_relationship(
+        "Accounts", account["id"], "contacts", page_size=1, page_number=1, sort_field="last_name", sort_dir="ascending"
+    )
+    assert relationships["data"][0]["attributes"]["last_name"] == "Contact 1"
+
+    relationships = crm.get_relationship(
+        "Accounts",
+        account["id"],
+        "contacts",
+        page_size=1,
+        page_number=1,
+        sort_field="last_name",
+        sort_dir="descending",
+    )
+    assert relationships["data"][0]["attributes"]["last_name"] == "Contact 9"
+
+    _delete_records(crm, [account] + contacts)

--- a/tests/integration/test_relationships.py
+++ b/tests/integration/test_relationships.py
@@ -78,7 +78,7 @@ def _create_account_contacts_and_relationships(crm, num_contacts: int):
         contact = crm.create_record("Contact", {"last_name": f"Contact {contact_idx}"})
         contacts.append(contact)
 
-    account = crm.create_record("Account", {"name": f"Organisation 1"})
+    account = crm.create_record("Account", {"name": "Organisation 1"})
 
     for contact in contacts:
         crm.create_relationship("Accounts", account["id"], "contacts", "Contacts", contact["id"])

--- a/tests/test_fix_suitecrm_escaping.py
+++ b/tests/test_fix_suitecrm_escaping.py
@@ -3,22 +3,37 @@ import pytest
 from libsuitecrm import SuiteCRM
 
 
-@pytest.mark.parametrize("input,expected", [
-    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'},
-     {"str": 'SuiteCRM mishandles: <, >, \', \', "'}],
-    [['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'], ['SuiteCRM mishandles: <, >, \', \', "']],
-    [['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
-      'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'],
-     ['SuiteCRM mishandles: <, >, \', \', "', 'SuiteCRM mishandles: <, >, \', \', "']],
-    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
-      "sublist": ['SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;']},
-      {"str": 'SuiteCRM mishandles: <, >, \', \', "',
-       "sublist": ['SuiteCRM mishandles: <, >, \', \', "']}],
-    [{"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;',
-      "subdict": {"str": 'SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;'}},
-      {"str": 'SuiteCRM mishandles: <, >, \', \', "',
-       "subdict": {"str": 'SuiteCRM mishandles: <, >, \', \', "'}}],
-])
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        [
+            {"str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"},
+            {"str": "SuiteCRM mishandles: <, >, ', ', \""},
+        ],
+        [["SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"], ["SuiteCRM mishandles: <, >, ', ', \""]],
+        [
+            [
+                "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+                "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+            ],
+            ["SuiteCRM mishandles: <, >, ', ', \"", "SuiteCRM mishandles: <, >, ', ', \""],
+        ],
+        [
+            {
+                "str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+                "sublist": ["SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"],
+            },
+            {"str": "SuiteCRM mishandles: <, >, ', ', \"", "sublist": ["SuiteCRM mishandles: <, >, ', ', \""]},
+        ],
+        [
+            {
+                "str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;",
+                "subdict": {"str": "SuiteCRM mishandles: &lt;, &gt;, &#39;, &#039;, &quot;"},
+            },
+            {"str": "SuiteCRM mishandles: <, >, ', ', \"", "subdict": {"str": "SuiteCRM mishandles: <, >, ', ', \""}},
+        ],
+    ],
+)
 def test_fix_escaped_characters(input, expected):
 
     crm = SuiteCRM(api_base_url="dummy_url", client_id="dummy", client_secret="dummy", secure=False)


### PR DESCRIPTION
This PR:
* Adds paging and sorting functionality to `get_relationship()`.
  * This is backwards compatible, just using extra `kwargs`.

It is a prerequisite for https://github.com/IATI/register-your-data-api/issues/15

Depends on https://github.com/IATI/iati-registry-libsuitecrm/pull/16