### PR TITLE
Adds support for SuiteCRM's `like` filter

### DIFF
--- a/libsuitecrm/filter.py
+++ b/libsuitecrm/filter.py
@@ -29,6 +29,10 @@ class Filter:
         self._operations.append((f"filter[{field}][lte]", value))
         return self
 
+    def like(self, field: str, value: str):
+        self._operations.append((f"filter[{field}][like]", value))
+        return self
+
     def op_and(self):
         self._operations.append(("filter[operator]", "and"))
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "libsuitecrm"
 description = "Library for interfacing with the SuiteCRM REST API focused on applications within IATI"
 authors = [{name="IATI Secretariat", email="support@iatistandard.org"}]
-version = "0.5.0"
+version = "0.5.1"
 requires-python = ">= 3.12.3"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -57,8 +57,6 @@ def test_filters(crm):
     )
     assert "data" in response
     assert isinstance(response["data"], list)
-    # print(test_records)
-    # [print(x["id"]) for x in response["data"]]
     assert len(response["data"]) == 2
     assert response["data"][0]["id"] == test_records[0]["id"]
     assert response["data"][1]["id"] == test_records[1]["id"]
@@ -75,8 +73,6 @@ def test_filters(crm):
     )
     assert "data" in response
     assert isinstance(response["data"], list)
-    # print(test_records)
-    # [print(x["id"]) for x in response["data"]]
     assert len(response["data"]) == 1
     assert response["data"][0]["id"] == test_records[5]["id"]
 
@@ -111,8 +107,6 @@ def test_filter_like(crm):
     )
     assert "data" in response
     assert isinstance(response["data"], list)
-    # print(test_records)
-    # [print(x["id"]) for x in response["data"]]
     assert len(response["data"]) == 3
     assert response["data"][0]["id"] == test_records[3]["id"]
     assert response["data"][1]["id"] == test_records[4]["id"]

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -83,6 +83,45 @@ def test_filters(crm):
     [crm.delete_record("Accounts", record["id"]) for record in test_records]
 
 
+def test_filter_like(crm):
+    test_records = [
+        {"name": "UK Person A", "country": "UK", "description": "Text 1"},
+        {"name": "UK Person B", "country": "UK", "description": "Text 1"},
+        {"name": "UK Person C", "country": "UK", "description": "Text 2"},
+        {"name": "German Person D", "country": "Germany", "description": "Text 1"},
+        {"name": "German Person E", "country": "Germany", "description": "Text 1"},
+        {"name": "German Person F", "country": "Germany", "description": "Text 2"},
+    ]
+
+    for index, record in enumerate(test_records):
+        test_records[index]["id"] = crm.create_record(
+            "Account",
+            {
+                "name": record["name"],
+                "description": record["description"],
+            },
+        )["id"]
+
+    response = crm.get_records(
+        "Accounts",
+        fields=["name", "description"],
+        sort_dir="ascending",
+        sort_field="name",
+        filters=libsuitecrm.Filter().like("name", "German%"),
+    )
+    assert "data" in response
+    assert isinstance(response["data"], list)
+    # print(test_records)
+    # [print(x["id"]) for x in response["data"]]
+    assert len(response["data"]) == 3
+    assert response["data"][0]["id"] == test_records[3]["id"]
+    assert response["data"][1]["id"] == test_records[4]["id"]
+    assert response["data"][2]["id"] == test_records[5]["id"]
+
+    for record in test_records:
+        crm.delete_record("Accounts", record["id"])
+
+
 def test_get_content_with_html_chars(crm):
     test_str = "Test special chars: <, >, &, \", '"
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -21,6 +21,8 @@ def test_operators():
         .lt("e", 10)
         .op_or()
         .lte("f", 100)
+        .op_or()
+        .like("g", "query")
         .operations
     )
     assert filters[0] == ("filter[a][neq]", "0")
@@ -34,3 +36,5 @@ def test_operators():
     assert filters[8] == ("filter[e][lt]", 10)
     assert filters[9] == ("filter[operator]", "or")
     assert filters[10] == ("filter[f][lte]", 100)
+    assert filters[11] == ("filter[operator]", "or")
+    assert filters[12] == ("filter[g][like]", "query")


### PR DESCRIPTION
This PR adds support for SuiteCRM's `like` filter. This filter is not very well documented (it's not listed in the V8 docs, but it is listed in V1 docs). But it seems to work well, and mirrors functionality of the searching available in the SuiteCRM UI.